### PR TITLE
Make it more resiliet to failures

### DIFF
--- a/AutoHathwayLogin.py
+++ b/AutoHathwayLogin.py
@@ -16,47 +16,54 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
  '''
-import httplib, urllib2, sys, time
-postUrl=None
+import urllib2, sys, time, socket
+
+userName="USERNAME"
+password="PASSWORD"
+
 sleepTime=30
+socket.setdefaulttimeout(sleepTime)
+
+hostname = ['login.hathway.com', '203.212.193.60', '203.212.193.61']
+url = "/bsp/login.do?action=doLoginSubmit&flowId=UserLogin&username=" + userName + "&password=" + password
+
 def setup():
-	global postUrl
-	if len(sys.argv) == 1:
-		userName="INSERT YOUR HATHWAY EMAIL"
-		password="INSERT YOUR HATHEAY PASSWORD"
-	else:
+	if len(sys.argv) > 1:
 		userName=sys.argv[1]
 		password=sys.argv[2]
 		sleepTime=sys.argv[3]
-	postUrl="http://login.hathway.com/bsp/login.do?action=doLoginSubmit&flowId=UserLogin&username="+userName+"&password="+password
 	
-
-
 def checkInternetConnectivity():
-	conn = httplib.HTTPConnection("www.google.com")
-	conn.request("GET", "/")
-	r1 = conn.getresponse()
-	status=r1.status
-	
-	if status != 302: 
-		return 0
-	else: 
-		return 1
-
+	x = 1
+	try:
+		socket.create_connection( ("www.google.com", 80) )
+	except:
+		x = 0
+	finally:
+		return x
 
 def connectToHathway():
 
-	urllib2.urlopen(postUrl)
+	if len(hostname) == 0:
+		sys.exit(1)
+	else:
+		for host in hostname:
+			real_host = "http://" + host + url
+			try:
+				sys.stdout.write("Trying to authenticate to server %s\n" % (real_host) )
+				urllib2.urlopen(real_host)
+			except:
+				sys.stderr.write("Failed to connect to %s Retrying\n" % (real_host) )
+				continue
 	
-
-
 setup()
 while 1==1:
 	if checkInternetConnectivity() == 0:
+		sys.stderr.write("Internet connectivity is dead. Trying to contact Hathway auth severs.\n")
 		connectToHathway()
 		time.sleep(sleepTime)
 		continue
 	else:
+		sys.stdout.write("Internet connectivity alive. Sleeping for %s seconds.\n" % (sleepTime) )
 		time.sleep(sleepTime)
 		continue 
-		


### PR DESCRIPTION
This happens because in your connection health check, there's no
exception handling.

rrs@debtor:~/AutoHathwayLogin-master$ python AutoHathwayLogin.py
Traceback (most recent call last):
  File "AutoHathwayLogin.py", line 55, in <module>
    if checkInternetConnectivity() == 0:
  File "AutoHathwayLogin.py", line 37, in checkInternetConnectivity
    conn.request("GET", "/")
  File "/usr/lib/python2.7/httplib.py", line 973, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python2.7/httplib.py", line 1007, in _send_request
    self.endheaders(body)
  File "/usr/lib/python2.7/httplib.py", line 969, in endheaders
    self._send_output(message_body)
  File "/usr/lib/python2.7/httplib.py", line 829, in _send_output
    self.send(msg)
  File "/usr/lib/python2.7/httplib.py", line 791, in send
    self.connect()
  File "/usr/lib/python2.7/httplib.py", line 772, in connect
    self.timeout, self.source_address)
  File "/usr/lib/python2.7/socket.py", line 553, in create_connection
    for res in getaddrinfo(host, port, 0, SOCK_STREAM):
socket.gaierror: [Errno -2] Name or service not known

Sample script output after the changes:

root@debtor:/home/rrs/AutoHathwayLogin-master# python
AutoHathwayLogin.py
1
Internet connectivity is dead. Trying to contact Hathway auth severs.
Trying to authenticate to server
http://login.hathway.com/bsp/login.do?action=doLoginSubmit&flowId=UserLogin&username=USERNAME&password=PASSWORD.
Failed to connect to
http://login.hathway.com/bsp/login.do?action=doLoginSubmit&flowId=UserLogin&username
thway.com&password=PASSWORD. Retrying
Trying to authenticate to server
http://203.212.193.60/bsp/login.do?action=doLoginSubmit&flowId=UserLogin&username=USERNAME&password=PASSWORD.
Failed to connect to
http://203.212.193.60/bsp/login.do?action=doLoginSubmit&flowId=UserLogin&username=USERNAME&password=PASSWORD.
Retrying
Trying to authenticate to server
http://203.212.193.61/bsp/login.do?action=doLoginSubmit&flowId=UserLogin&username=USERNAME&password=PASSWORD.
Failed to connect to
http://203.212.193.61/bsp/login.do?action=doLoginSubmit&flowId=UserLogin&username=USERNAME&password=PASSWORD.
Retrying
Internet connectivity is dead. Trying to contact Hathway auth severs.
Trying to authenticate to server
http://login.hathway.com/bsp/login.do?action=doLoginSubmit&flowId=UserLogin&username=USERNAME&password=PASSWORD.
Failed to connect to
http://login.hathway.com/bsp/login.do?action=doLoginSubmit&flowId=UserLogin&username=USERNAME&password=PASSWORD.
Retrying
Trying to authenticate to server
http://203.212.193.60/bsp/login.do?action=doLoginSubmit&flowId=UserLogin&username=USERNAME&password=PASSWORD.
Trying to authenticate to server
http://203.212.193.61/bsp/login.do?action=doLoginSubmit&flowId=UserLogin&username=USERNAME&password=PASSWORD.
Internet connectivity alive. Sleeping for 30 seconds.
Internet connectivity alive. Sleeping for 30 seconds.
Internet connectivity alive. Sleeping for 30 seconds.
Internet connectivity alive. Sleeping for 30 seconds.
Internet connectivity alive. Sleeping for 30 seconds.
Internet connectivity alive. Sleeping for 30 seconds.
Internet connectivity alive. Sleeping for 30 seconds.
Internet connectivity alive. Sleeping for 30 seconds.
Internet connectivity alive. Sleeping for 30 seconds.
Internet connectivity alive. Sleeping for 30 seconds.
Internet connectivity alive. Sleeping for 30 seconds.
Internet connectivity alive. Sleeping for 30 seconds.
Internet connectivity alive. Sleeping for 30 seconds.
Internet connectivity alive. Sleeping for 30 seconds.
Internet connectivity alive. Sleeping for 30 seconds.
Internet connectivity alive. Sleeping for 30 seconds.
Internet connectivity alive. Sleeping for 30 seconds.
